### PR TITLE
No redundant imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Thumbs.db
 netbeans/
 nbproject/
 .komodoproject/
+*.iml
 
 #Node JS#
 node_modules/

--- a/app/collections/library.js
+++ b/app/collections/library.js
@@ -8,9 +8,7 @@
  */
 /*global views, console, $, $$, TweenLite, TweenMax, TimelineLite, TimelineMax, Ease, Linear, Power0, Power1, Power2, Power3, Power4, Quad, Cubic, Quart, Strong, Back, Bounce, Circ, Elastic, Expo, Sine, SlowMo  */
 
-define(['backbone',
-        'underscore',
-        'app/models/library'], function (Backbone, _, Model) {
+define(['app/models/library'], function (Model) {
 
     'use strict';
 

--- a/app/collections/timeline.js
+++ b/app/collections/timeline.js
@@ -8,7 +8,7 @@
  */
 /*global views, console, $, define  */
 
-define(['backbone', 'underscore', 'app/models/layer'], function (Backbone, _, Model) {
+define(['app/models/layer'], function (Model) {
 
     'use strict';
 

--- a/app/controllers/timeline.js
+++ b/app/controllers/timeline.js
@@ -8,7 +8,7 @@
  */
 /*global views, console, $, $$, TweenLite, TweenMax, TimelineLite, TimelineMax, Ease, Linear, Power0, Power1, Power2, Power3, Power4, Quad, Cubic, Quart, Strong, Back, Bounce, Circ, Elastic, Expo, Sine, SlowMo  */
 
-define(['backbone', 'underscore', 'app/collections/timeline'], function (Backbone, _, Collection) {
+define(['app/collections/timeline'], function (Collection) {
 
     'use strict';
 

--- a/app/models/layer.js
+++ b/app/models/layer.js
@@ -8,7 +8,7 @@
  */
 /*global views, console, $, $$, TweenLite, TweenMax, TimelineLite, TimelineMax, Ease, Linear, Power0, Power1, Power2, Power3, Power4, Quad, Cubic, Quart, Strong, Back, Bounce, Circ, Elastic, Expo, Sine, SlowMo  */
 
-define(['backbone', 'underscore'], function (Backbone, _) {
+define([], function () {
 
     'use strict';
 

--- a/app/models/library.js
+++ b/app/models/library.js
@@ -8,7 +8,7 @@
  */
 /*global views, console, $, $$, TweenLite, TweenMax, TimelineLite, TimelineMax, Ease, Linear, Power0, Power1, Power2, Power3, Power4, Quad, Cubic, Quart, Strong, Back, Bounce, Circ, Elastic, Expo, Sine, SlowMo  */
 
-define(['backbone', 'underscore'], function (Backbone, _) {
+define([], function () {
 
     'use strict';
 

--- a/app/project-touch.js
+++ b/app/project-touch.js
@@ -19,7 +19,7 @@ Number.prototype.toMMSS = function () {
     return time;
 }
 
-define(['backbone', 'app/views/player', 'app/filters', 'app/views/ui/library', 'app/views/ui/effects', 'app/views/ui/edit', 'app/controllers/timeline', 'app/views/ui/timeline', 'app/views/composition'], function (Backbone) {
+define(['app/views/player', 'app/filters', 'app/views/ui/library', 'app/views/ui/effects', 'app/views/ui/edit', 'app/controllers/timeline', 'app/views/ui/timeline', 'app/views/composition'], function () {
 
     'use strict';
 

--- a/app/views/composition.js
+++ b/app/views/composition.js
@@ -6,7 +6,7 @@
 
 /*global define, window, document, $, requirejs, require  */
 
-define(['backbone', 'underscore'], function (Backbone, _) {
+define([], function () {
 
     'use strict';
 

--- a/app/views/panel.js
+++ b/app/views/panel.js
@@ -6,7 +6,7 @@
 
 /*global define, window, document, $, requirejs, require  */
 
-define(['backbone', 'underscore'], function (Backbone, _) {
+define([], function () {
 
     return Backbone.View.extend({
 

--- a/app/views/player.js
+++ b/app/views/player.js
@@ -6,7 +6,7 @@
 
 /*global define, window, document, $, requirejs, require  */
 
-define(['backbone', 'underscore'], function (Backbone, _) {
+define([], function () {
 
     'use strict';
 

--- a/app/views/ui/edit-level.js
+++ b/app/views/ui/edit-level.js
@@ -9,7 +9,7 @@
 
 /*global define, window, document, $, requirejs, require  */
 
-define(['backbone', 'underscore'], function (Backbone, _) {
+define([], function () {
 
     'use strict';
 

--- a/app/views/ui/library-item.js
+++ b/app/views/ui/library-item.js
@@ -6,7 +6,7 @@
 
 /*global define, window, document, $, requirejs, require  */
 
-define(['backbone', 'underscore', "app/views/player", "app/filters"], function (Backbone, _, Player, Filter) {
+define(["app/views/player", "app/filters"], function (Player, Filter) {
 
     'use strict';
 

--- a/app/views/ui/timeline-layer-slide.js
+++ b/app/views/ui/timeline-layer-slide.js
@@ -6,7 +6,7 @@
 
 /*global define, window, document, $, requirejs, require  */
 
-define(['backbone', 'underscore'], function (Backbone, _) {
+define([], function () {
 
     'use strict';
 

--- a/app/views/ui/timeline-layer.js
+++ b/app/views/ui/timeline-layer.js
@@ -6,7 +6,7 @@
 
 /*global define, window, document, $, requirejs, require  */
 
-define(['backbone', 'underscore', 'app/views/ui/timeline-layer-slide'], function (Backbone, _, Slide) {
+define(['app/views/ui/timeline-layer-slide'], function (Slide) {
 
     'use strict';
 

--- a/app/views/ui/timeline.js
+++ b/app/views/ui/timeline.js
@@ -6,7 +6,7 @@
 
 /*global define, window, document, $, requirejs, require  */
 
-define(['backbone', 'underscore', 'app/views/ui/timeline-layer', 'app/views/ui/effects'], function (Backbone, _, Layer) {
+define(['app/views/ui/timeline-layer', 'app/views/ui/effects'], function (Layer) {
 
     'use strict';
 

--- a/application.js
+++ b/application.js
@@ -34,15 +34,20 @@ requirejs.config({
     }
 });
 
-require(['app/project-touch', 'hammer', 'stats'], function (PT) {
+//Enforce loading global libraries first
+require(['backbone', 'underscore', 'hammer', 'stats'], function (PT) {
 
-    'use strict';
+    require(['app/project-touch'], function (PT) {
 
-    window.log = Function.prototype.bind.call(console.log, console);
+        'use strict';
 
-    window.App = new PT({
-        el: document.querySelector('.video')
+        window.log = Function.prototype.bind.call(console.log, console);
+
+        window.App = new PT({
+            el: document.querySelector('.video')
+        });
+        window.App.render();
+
     });
-    window.App.render();
 
 });


### PR DESCRIPTION
Instead of requiring both backbone and underscore for most libraries, I'd like to propose to load them globally and don't worry about these redundant imports anymore.
This prevents repeating ourselves unnecessarily and keeps the code a bit cleaner.
